### PR TITLE
Add test and doc targets to Ant build file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -287,7 +287,7 @@
 	<!--
      #  ********** Test *************
      -->
-	<target name="build-test" depends="stage.war"
+	<target name="build-test" depends="stage.war,compile.java"
 		description="test the project" >
             <javac srcdir            = "${test.src}"
 		   destdir           = "${classes}"


### PR DESCRIPTION
I've added three targets to the Ant build file
1. "build-test" which builds all tests in test/\* into build/classes/
2. "test" which invokes a JUnit target on anything called *TestCase
3. "doc" which simply builds API docs to docs/

I've been as consistent with whitespace as I can be, but I'll note that the spacing in build.xml seems to mix tabs and spaces, whereas in the style in .java files doesn't mix spaces and tabs.
