### PR TITLE
Logback missing janino lib fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - oraclejdk11
 before_script:
-  - mkdir /var/log/webprotege
+  - sudo mkdir /var/log/webprotege
 script: mvn verify
 sudo: false
 services: mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 jdk:
   - oraclejdk11
+before_script:
+  - mkdir /var/log/webprotege
 script: mvn verify
 sudo: false
 services: mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - oraclejdk11
 before_script:
-  - sudo mkdir /var/log/webprotege
+  - sudo mkdir /var/log/webprotege && sudo chown travis /var/log/webprotege
 script: mvn verify
 sudo: false
 services: mongodb

--- a/webprotege-server/pom.xml
+++ b/webprotege-server/pom.xml
@@ -162,6 +162,14 @@
             <artifactId>junit</artifactId>
         </dependency>
 
+        <!-- The org.codehaus.janino:commons-compiler:3.0.6 dependency -->
+        <!-- required for logback' conditional processing of paths -->
+        <dependency>
+          <groupId>org.codehaus.janino</groupId>
+          <artifactId>janino</artifactId>
+          <version>3.0.6</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/webprotege-server/src/main/resources/logback.xml
+++ b/webprotege-server/src/main/resources/logback.xml
@@ -23,7 +23,7 @@
         <file>${logsdir}/webprotege.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
-            <fileNamePattern>${logsdir}/webprotege.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${logsdir}/webprotege.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
             <maxHistory>60</maxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
@@ -35,7 +35,7 @@
         <file>${logsdir}/webprotege-all.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
-            <fileNamePattern>${logsdir}/webprotege-all.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${logsdir}/webprotege-all.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
             <maxHistory>60</maxHistory>
         </rollingPolicy>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">


### PR DESCRIPTION
logback.xml uses conditional processing to set custom log path based on the OS
https://github.com/protegeproject/webprotege/blob/88339a4feb9bd61514439ee9bdd2be4007be8899/webprotege-server/src/main/resources/logback.xml#L5
This requires Janino library http://logback.qos.ch/setup.html#janino to operate properly.  Without this library webprotege logs go to logsdir_IS_UNDEFINED.  

This fix adds missing library to pom and also enables compression for rotated log files

Alternatively this could be addressed with converting logback xml config to groovy 