### PR TITLE
Docker - allow running as non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,9 @@ WORKDIR /usr/local/tomcat/webapps/ROOT
 COPY --from=build /webprotege/webprotege-cli/target/webprotege-cli-4.0.0-beta-3-SNAPSHOT.jar /webprotege-cli.jar
 COPY --from=build /webprotege/webprotege-server/target/webprotege-server-4.0.0-beta-3-SNAPSHOT.war ./webprotege.war
 RUN unzip webprotege.war \
-    && rm webprotege.war
+    && rm webprotege.war \
+    && chmod -R a+rwx /srv/webprotege \
+    && chmod -R a+rwx /usr/local/tomcat/temp \
+    && mkdir -p /var/log/webprotege \
+    && chmod -R a+rwx /var/log/webprotege
+    

--- a/webprotege-client/pom.xml
+++ b/webprotege-client/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>owlapi-gwt</artifactId>
-            <version>4.3.2.1-SNAPSHOT</version>
+            <version>4.3.2.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.sourceforge.owlapi</groupId>

--- a/webprotege-server/pom.xml
+++ b/webprotege-server/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
             <artifactId>owlapi-gwt</artifactId>
-            <version>4.3.2.1-SNAPSHOT</version>
+            <version>4.3.2.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.sourceforge.owlapi</groupId>


### PR DESCRIPTION
cc @gebn

Hello,

It's not possible to run the current image as non-root user.  The `chmod`s and `mkdir` in Dockerfile allow non-root user.  

Apologies, just spotted that #675 changes have been included here (i'll resubmit on guidance).

Thanks