### PR TITLE
Fix #700. Set to silently ignore UnloadableImportException

### DIFF
--- a/webprotege-client/src/main/java/edu/stanford/bmir/protege/web/client/Messages.java
+++ b/webprotege-client/src/main/java/edu/stanford/bmir/protege/web/client/Messages.java
@@ -723,6 +723,10 @@ public interface Messages extends com.google.gwt.i18n.client.Messages {
     @Key("projectSettings.language.helpText")
     SafeHtml projectSettings_language_helpText();
 
+    @DefaultMessage("Any owl:import that cannot be loaded will be silently ignored")
+    @Key("projectSettings.owlimport.helpText")
+    SafeHtml projectSettings_owl_import_helpText();
+
     
     @DefaultMessage("Display name")
     @Key("projectSettings.displayName")

--- a/webprotege-client/src/main/java/edu/stanford/bmir/protege/web/client/project/CreateNewProjectViewImpl.ui.xml
+++ b/webprotege-client/src/main/java/edu/stanford/bmir/protege/web/client/project/CreateNewProjectViewImpl.ui.xml
@@ -38,6 +38,7 @@
                     <g:FileUpload ui:field="fileUpload"/>
                 </g:FormPanel>
             </g:HTMLPanel>
+            <label class="{wp.style.formHelpText} {style.helpText}"><ui:safehtml from="{msg.projectSettings_owl_import_helpText}"/></label>
         </g:HTMLPanel>
 
     </g:HTMLPanel>

--- a/webprotege-server-core/src/main/java/edu/stanford/bmir/protege/web/server/upload/UploadedOntologiesProcessor.java
+++ b/webprotege-server-core/src/main/java/edu/stanford/bmir/protege/web/server/upload/UploadedOntologiesProcessor.java
@@ -5,6 +5,7 @@ import edu.stanford.bmir.protege.web.server.project.Ontology;
 import edu.stanford.bmir.protege.web.server.project.RawProjectSourcesImporter;
 import edu.stanford.bmir.protege.web.server.project.UploadedProjectSourcesExtractor;
 import edu.stanford.bmir.protege.web.shared.csv.DocumentId;
+import org.semanticweb.owlapi.model.MissingImportHandlingStrategy;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
@@ -50,7 +51,9 @@ public class UploadedOntologiesProcessor {
         var uploadedFile = documentResolver.resolve(documentId).toFile();
         var uploadedProjectSourcesExtractor = uploadedProjectSourcesExtractorProvider.get();
         var rawProjectSources = uploadedProjectSourcesExtractor.extractProjectSources(uploadedFile);
-        var loaderConfig = new OWLOntologyLoaderConfiguration();
+        var loaderConfig = new OWLOntologyLoaderConfiguration()
+                // See https://github.com/protegeproject/webprotege/issues/700
+                .setMissingImportHandlingStrategy(MissingImportHandlingStrategy.SILENT);
         var rawProjectSourcesImporter = new RawProjectSourcesImporter(manager, loaderConfig);
         rawProjectSourcesImporter.importRawProjectSources(rawProjectSources);
         return manager.getOntologies()


### PR DESCRIPTION
- Added `MissingImportHandlingStrategy.SILENT` to the loader configuration to silently ignore non-loadable imports,
- Added help text to the project creation dialog to signal that.

Screenshot: 

![image](https://user-images.githubusercontent.com/189642/89273934-85d80800-d640-11ea-8d8a-2253f43c3d99.png)
