### PR TITLE
Fix for IllegalArgumentException: null lang in AnnotationAssertionPathDictionaryLanguage

### DIFF
--- a/webprotege-shared/src/main/java/edu/stanford/bmir/protege/web/shared/shortform/AnnotationAssertionPathDictionaryLanguage.java
+++ b/webprotege-shared/src/main/java/edu/stanford/bmir/protege/web/shared/shortform/AnnotationAssertionPathDictionaryLanguage.java
@@ -37,7 +37,9 @@ public abstract class AnnotationAssertionPathDictionaryLanguage extends Dictiona
     @Nonnull
     public static AnnotationAssertionPathDictionaryLanguage get(@JsonProperty(PATH) @Nonnull ImmutableList<IRI> path,
                                                                 @JsonProperty(LANG) @Nonnull String newLang) {
-        return new AutoValue_AnnotationAssertionPathDictionaryLanguage(path, newLang);
+        if (newLang == null || newLang.trim() == "")
+            newLang = "en";
+	return new AutoValue_AnnotationAssertionPathDictionaryLanguage(path, newLang);
     }
 
     @Override


### PR DESCRIPTION
- See  #765 for details
- when adding Display name property and language priority and language is null, then default to "en"