### PR TITLE
Fix Flaky Test in SubjectClosureResolver_TestCase

### DIFF
--- a/webprotege-server-api/src/test/java/edu/stanford/bmir/protege/web/server/entity/SubjectClosureResolver_TestCase.java
+++ b/webprotege-server-api/src/test/java/edu/stanford/bmir/protege/web/server/entity/SubjectClosureResolver_TestCase.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItems;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -69,7 +70,7 @@ public class SubjectClosureResolver_TestCase {
         when(axiom.getSubject()).thenReturn(clsIri);
         var rootEntities = resolver.resolve(valueEntity)
                 .collect(toSet());
-        assertThat(rootEntities, contains(cls, valueEntity));
+        assertThat(rootEntities, hasItems(cls, valueEntity));
     }
 
     @Test


### PR DESCRIPTION
A flaky test was fixed in this pull request-

1. edu.stanford.bmir.protege.web.server.entity.SubjectClosureResolver_TestCase.shouldGetClsAsRootEntity

### Flakiness in the tests - 
To check for flakiness in the tests, a tool called [nondex](https://github.com/TestingResearchIllinois/NonDex) was used. 

### Steps to reproduce flakiness using nondex - 
**Test 1:**
```
mvn install -pl webprotege-server-api -am -DskipTests
mvn -pl webprotege-server-api test -Dtest=edu.stanford.bmir.protege.web.server.entity.SubjectClosureResolver_TestCase
mvn -pl webprotege-server-api edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=edu.stanford.bmir.protege.web.server.entity.SubjectClosureResolver_TestCase
```

The third command shows us the flakiness in the test. There are test failures due to **differences in the order of elements**
<img width="641" alt="Screenshot 2024-10-31 140226" src="https://github.com/user-attachments/assets/8e2002e3-efe5-4c96-8a4c-d25689b96c84">

Source of Flakiness in the test and fix:
The object rootEntities is a set and sets in Java have no order. However, the check being carried out was -  assertThat(rootEntities, contains(cls, valueEntity));
The contains() method checks if the two objects cls and valueEntity are present in the exact order in which they are mentioned and this fails if the order in the set is different from the order mentioned.

To fix this, contains() is replaced by hasItems() which does not check the order of items.


Code change-
assertThat(rootEntities, hasItems(cls, valueEntity));



Please let me know if you have any questions or need any additional justification/changes from my side.



